### PR TITLE
Support for certificates from keyvault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.3.0
+
+- add support for managed identities.
+
 ## v2.2.2
 
 - Fix output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v2.3.0
 
 - add support for managed identities.
+- add support for SSL certificate in KeyVault.
 
 ## v2.2.2
 

--- a/main.tf
+++ b/main.tf
@@ -115,8 +115,9 @@ resource "azurerm_application_gateway" "application-gw" {
     for_each = var.ssl_certificates
     content {
       name = ssl_certificate.value.name
-      data = ssl_certificate.value.data
+      data = lookup(ssl_certificate.value, "data", null)
       password = ssl_certificate.value.password
+      key_vault_secret_id = lookup(ssl_certificate.value, "key_vault_secret_id", null)
     }
   }
 
@@ -184,6 +185,15 @@ resource "azurerm_application_gateway" "application-gw" {
     content {
       status_code                    = custom_error_configuration.value.status_code
       custom_error_page_url          = custom_error_configuration.value.custom_error_page_url
+    }
+  }
+
+  dynamic "identity" {
+    for_each = var.identity_ids
+
+    content {
+      type          = "UserAssigned"
+      identity_ids  = var.identity_ids
     }
   }
 }
@@ -290,9 +300,10 @@ resource "azurerm_application_gateway" "application-gw-no-ssl" {
   dynamic "ssl_certificate" {
     for_each = var.ssl_certificates
     content {
-      name = ssl_certificate.value.name
-      data = ssl_certificate.value.data
-      password = ssl_certificate.value.password
+      name                = ssl_certificate.value.name
+      data                = ssl_certificate.value.data
+      password            = ssl_certificate.value.password
+      key_vault_secret_id = ssl_certificate.value.key_vault_secret_id
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -163,3 +163,10 @@ variable "lifecycle_ignore_ssl" {
   description   = "Whether to ignore future changes on SSL certificates (e.g: handled by an external component). Changing this forces a new resource to be created."
   default       = false
 }
+
+variable "identity_ids" {
+  type            = list(string)
+  description     = "(Optional) For TLS termination with Key Vault certificates, define a list of user-assigned managed identity, which Application Gateway uses to retrieve certificates from Key Vault."
+  default         = []
+}
+


### PR DESCRIPTION
We can now use a SSL certificate that is stored in KeyVault, by using an identity.